### PR TITLE
fix: typo in dependency name

### DIFF
--- a/environment_comfortable_py10.yml
+++ b/environment_comfortable_py10.yml
@@ -24,7 +24,7 @@ dependencies:
   - scikit-sparse
   - tqdm
   - conda-forge::mayavi>=4.8
-  - conda-forge::PySide6==6.7.1
+  - conda-forge::pyside6==6.7.1
   - conda-forge::ffmpeg-python
   - pip:
     - distutils


### PR DESCRIPTION
Current name causes an error, updated according to the given link below:

https://anaconda.org/conda-forge/pyside6